### PR TITLE
Stop QC when IPT resource cannot be retrieved

### DIFF
--- a/R/checkdataset.R
+++ b/R/checkdataset.R
@@ -28,7 +28,9 @@ checkdataset = function(Event = NULL, Occurrence = NULL, eMoF = NULL, IPTreport 
   
   
   # if (exists("IPTreport") == FALSE ) {IPTreport <- list()} # To use checkdataset only with tables and no importiptdata()
-  
+  if (!is.null(IPTreport$error)) { 
+    stop(IPTreport$error) 
+  }
   if (!is.null(IPTreport$Event)) { 
     if (is.data.frame(IPTreport$Event)) {
       Event <- IPTreport$Event


### PR DESCRIPTION
QC will stop when IPT resource fails to be retrieved (e.g. private IPT resources). It should only affect datasets checked via the IPT resource url since it operates on the error generated by `importiptdata.R`