### PR TITLE
Add QC checks for DNA data

### DIFF
--- a/R/checkdataset.R
+++ b/R/checkdataset.R
@@ -20,8 +20,7 @@
 #' }
 
 
-checkdataset = function(Event = NULL, Occurrence = NULL, eMoF = NULL, IPTreport = list(), tree = FALSE){
-
+checkdataset = function(Event = NULL, Occurrence = NULL, eMoF = NULL, DNA = NULL, IPTreport = list(), tree = FALSE){
   
   ###### Extracting tables from IPTreport list, which is the output of importiptdata()
   ######-------------------------------------------------------------------------------
@@ -34,20 +33,26 @@ checkdataset = function(Event = NULL, Occurrence = NULL, eMoF = NULL, IPTreport 
   if (!is.null(IPTreport$Event)) { 
     if (is.data.frame(IPTreport$Event)) {
       Event <- IPTreport$Event
-  }}
+    }}
   if (!is.null(IPTreport$Occurrence)) { 
     if (is.data.frame(IPTreport$Occurrence)) {
       Occurrence <- IPTreport$Occurrence
-  }}
+    }}
   if (!is.null(IPTreport$eMoF)) { 
     if (is.data.frame(IPTreport$eMoF)) {
       eMoF <- IPTreport$eMoF
-  }}
+    }}
+  if (!is.null(IPTreport$DNA)) { 
+    if (is.data.frame(IPTreport$DNA)) {
+      DNA <- IPTreport$DNA
+    }}
   
   # Remove R objects if they are null
   if (is.null(Event)) {rm(Event)}
   if (is.null(eMoF)) {rm(eMoF)}
   if (is.null(Occurrence)) {rm(Occurrence)}
+  if (is.null(DNA)) {rm(DNA)}
+  
 
 
   #---------------------------------------------------------------------------#

--- a/R/checkdataset.R
+++ b/R/checkdataset.R
@@ -831,7 +831,15 @@ checkdataset = function(Event = NULL, Occurrence = NULL, eMoF = NULL, DNA = NULL
       oc_CheckFields <- check_fields(Occurrence, level = "warning")
     }}
   
-  
+ 
+    
+    # Checks run only when the DNA table exists
+    #---------------------------------------------
+    
+  if (  exists("DNA") ){
+    dna_checkFields <- check_required_fields_dna(Occurrence, DNA)
+  }
+    
       # Checks one to one relationship issues
       #---------------------------------------
   
@@ -910,6 +918,9 @@ checkdataset = function(Event = NULL, Occurrence = NULL, eMoF = NULL, DNA = NULL
                           if(exists("ev_CheckFields")) ev_CheckFields,
                           if(exists("no_ev_datasetName")) no_ev_datasetName,
                           if(exists("no_ev_institutionCode")) no_ev_institutionCode)
+  
+  dnaerror <- bind_rows(if(exists("dnaerror") & nrow(dnaerror) > 0) dnaerror, 
+                        if(exists("dna_checkFields")) dna_checkFields)
   
   
   

--- a/R/checkdataset.R
+++ b/R/checkdataset.R
@@ -1601,6 +1601,12 @@ if(exists("Occurrence")){
     occurrenceerror <- rbind(occurrenceerror, occ_notmatched)          
   }
 }
+  # Checking content of DNA related fields
+  #-----------------------------------------------
+if(exists("DNA")){
+  dnaerror <- rbind(dnaerror, check_content_dna_fields(Occurrence, DNA))
+}
+  
   #-------------------------------------------------------------------------------#
   ####                    Generate report table                                ####
   #-------------------------------------------------------------------------------#

--- a/R/importiptdata.R
+++ b/R/importiptdata.R
@@ -89,6 +89,11 @@ if (exists("out") == FALSE) {
     output$warning <- ("The dataset does not have an occurrence file")
     }
   
+  if (is.null(out$data[["dnaderiveddata.txt"]]) == FALSE){
+    output$DNA <-out$data[["dnaderiveddata.txt"]]  
+  }
+  
+  
   if (is.null(out$data[["extendedmeasurementorfact.txt"]]) == FALSE){
     eMoF <-out$data[["extendedmeasurementorfact.txt"]]  
       }

--- a/R/smallfunctions.R
+++ b/R/smallfunctions.R
@@ -273,7 +273,7 @@ check_required_fields_dna <- function(occ, dna) {
       highly_recommended_fields <- c("DNA_sequence", "organismQuantity","organismQuantityType","sampleSizeValue","sampleSizeUnit","identificationRemarks","identificationReferences","taxonConceptID","materialSampleID","pcr_primer_forward","pcr_primer_reverse","pcr_primer_name_forward","pcr_primer_name_reverse","pcr_primer_reference","seq_meth","otu_class_appr")
     } else {
       #if not, enriched occurrence is assumed
-      required_fields <- c("Req1", "target_gene")
+      required_fields <- c("target_gene")
       highly_recommended_fields <- c("DNA_sequence", "associatedSequences", "pcr_primer_forward","pcr_primer_reverse","pcr_primer_name_forward","pcr_primer_name_reverse","pcr_primer_reference","seq_meth")
     }
   }
@@ -297,4 +297,38 @@ check_required_fields_dna <- function(occ, dna) {
   } else {
     return(tibble())
   }
+}
+
+#check content of DNA related fields
+check_content_dna_fields <- function(occ, dna){
+  error <- tibble()
+  if("organismQuantityType" %in% names(occ) && any(occ$organismQuantityType != "DNA sequence reads")){
+    error <- bind_rows(error, tibble(
+        field = "organismQuantityType",
+        level = "warning",
+        row = which(occ$organismQuantityType != "DNA sequence reads"),
+        message = "organismQuantity must be 'DNA sequence reads'"
+    ))
+  }
+  if("sampleSizeUnit" %in% names(occ) && any(occ$sampleSizeUnit != "DNA sequence reads")){
+    error <- bind_rows(error, tibble(
+      field = "sampleSizeUnit",
+      level = "warning",
+      row = which(occ$sampleSizeUnit != "DNA sequence reads"),
+      message = "sampleSizeUnit must be 'DNA sequence reads'"
+    ))
+  }
+  # DNA_sequence should only contain A,C,G,T,R,Y,K,M,S,W,B,D,H,V,N (nucleotides or ambiguity codes)
+  if("DNA_sequence" %in% names(dna)){
+    invalid_dna_sequences <- which(!grepl("^[ACGTRYKMSWBDHVN]*$", dna$DNA_sequence, ignore.case = TRUE))
+    if(length(invalid_dna_sequences) > 0){
+      error <- bind_rows(error, tibble(
+        field = "DNA_sequence",
+        level = "error",
+        row = invalid_dna_sequences,
+        message = "DNA_sequence contains invalid characters. Only A,C,G,T,R,Y,K,M,S,W,B,D,H,V,N are allowed."
+      ))
+    }
+  }
+  return(error)
 }

--- a/R/smallfunctions.R
+++ b/R/smallfunctions.R
@@ -245,3 +245,19 @@ new_data_frame[new_data_frame =='NA' | new_data_frame =='' | new_data_frame ==' 
 return(new_data_frame)
 
 }
+
+#Check if occurrenceID in extension exists in occurrence core (code adapted from obistools::check_extension_eventids())
+check_extension_occurrenceids <- function(occurrence, extension, field = "occurrenceID") {
+  rows <- which(!extension[[field]] %in% occurrence$occurrenceID)
+  if (length(rows) > 0) {
+    return(data.frame(
+      field = field,
+      level = "error",
+      row = rows,
+      message = paste0(field, " ", extension[[field]][rows], " has no corresponding occurrenceID in the occurrence table"),
+      stringsAsFactors = FALSE
+    ))
+  } else {
+    return(tibble())
+  }
+}


### PR DESCRIPTION
Adding the following QC checks for DNA data:

- integrity check on the DNA extension
- checking for required/highly recommended fields according to the EMODnet Biology guidelines
- some checks on content of DNA related fields