### PR TITLE
Refactor check_fields filtering for Occurrence

### DIFF
--- a/R/checkdataset.R
+++ b/R/checkdataset.R
@@ -820,7 +820,9 @@ checkdataset = function(Event = NULL, Occurrence = NULL, eMoF = NULL, DNA = NULL
       ev_CheckFields <- check_fields(ev_flat, level = "warning") %>% filter (field %in% event_fields())
       
       if (  exists("Occurrence") ){
-        oc_CheckFields <- check_fields(Occurrence, level = "warning") %>% filter (!field %in% event_fields())
+                oc_CheckFields <- check_fields(Occurrence, level = "warning") %>%
+                                      filter(if_any(any_of("field"),
+                                                    ~ !.x %in% event_fields()))
         }
       
       } else {


### PR DESCRIPTION
App fails when running on https://ipt.gbif.es/resource?r=icm-bioacoustics
The issue comes because check_fields() returns a 0×0 tibble, so filter(!field %in% …) fails because "field" doesn’t exist.

The patch I suggest (please double check it) let the code continue if there is nothing to filter on.
May need to be applied to every case where a 0×0 tibble is  could potentially be generated and something needs to be done with it afterwards.


I knew we would keep on working together :) 
Great job guys!